### PR TITLE
AL-3419: Restore foreignObject public API methods

### DIFF
--- a/src/commands/math/foreignObject.ts
+++ b/src/commands/math/foreignObject.ts
@@ -9,7 +9,9 @@
  * representation from the actual DOM structure and component lifecycle.
  */
 class ForeignObjectCommand extends MQSymbol {
-  private objectId: string = '';
+  static isForeignObject = true;
+
+  public objectId: string = '';
   private registry: ForeignObjectRegistry | null;
 
   /**

--- a/src/commands/math/foreignObject.ts
+++ b/src/commands/math/foreignObject.ts
@@ -9,8 +9,6 @@
  * representation from the actual DOM structure and component lifecycle.
  */
 class ForeignObjectCommand extends MQSymbol {
-  static isForeignObject = true;
-
   public objectId: string = '';
   private registry: ForeignObjectRegistry | null;
 

--- a/src/css/foreignObject.less
+++ b/src/css/foreignObject.less
@@ -2,8 +2,12 @@
 // Styles for embedded external HTMLElements in math expressions
 
 .mq-foreign-object-container {
-  .inline-block;
-  vertical-align: middle;
+  // inline-flex so the container's baseline equals the baseline of its first
+  // flex item — when the embedded content is a MathQuill-rendered fraction,
+  // this anchors the outer math to that fraction's bar (matching how native
+  // MathQuill fractions align). vertical-align: middle would instead anchor
+  // to the geometric centre, which looks wrong for tall/asymmetric content.
+  display: inline-flex;
   margin: 0 0.2em;
 
   // Prevent MathQuill from applying math-specific styles to embedded content

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -82,7 +82,7 @@ declare namespace MathQuill {
         id: string,
         element: HTMLElement
       ): EditableMathQuill;
-      foreignObject(id: string, element: HTMLElement): EditableMathQuill;
+      unregisterForeignObject(id: string): boolean;
     }
 
     interface API {

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -77,6 +77,11 @@ declare namespace MathQuill {
       clickAt: (x: number, y: number, el: HTMLElement) => EditableMathQuill;
 
       // Foreign Object API
+      getForeignObject(id: string): HTMLElement | null;
+      registerForeignObject(
+        id: string,
+        element: HTMLElement
+      ): EditableMathQuill;
       foreignObject(id: string, element: HTMLElement): EditableMathQuill;
     }
 

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -142,6 +142,7 @@ declare namespace MathQuill {
       statelessClipboard?: boolean;
       onPaste?: () => void;
       onCut?: () => void;
+      confirmForeignObjectDelete?: (objectId: string) => boolean;
       overrideTypedText?: (text: string) => void;
       overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
       autoOperatorNames?: string;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -369,6 +369,9 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       this.__controller.getForeignObjectRegistry().register(id, element);
       return this;
     }
+    unregisterForeignObject(id: string): boolean {
+      return this.__controller.getForeignObjectRegistry().unregister(id);
+    }
   }
 
   abstract class EditableField
@@ -397,13 +400,6 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       const cursor = this.__controller.cursor;
       if (this.__controller.blurred) cursor.hide().parent.blur(cursor);
       return this;
-    }
-    foreignObject(id: string, element: HTMLElement) {
-      // Register the foreign object in the internal registry
-      this.__controller.getForeignObjectRegistry().register(id, element);
-
-      // Insert the LaTeX command at cursor position
-      return this.write('\\foreignobject{' + id + '}');
     }
     empty() {
       var root = this.__controller.root,

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -362,6 +362,13 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       });
       return this;
     }
+    getForeignObject(id: string): HTMLElement | null {
+      return this.__controller.getForeignObjectRegistry().get(id);
+    }
+    registerForeignObject(id: string, element: HTMLElement) {
+      this.__controller.getForeignObjectRegistry().register(id, element);
+      return this;
+    }
   }
 
   abstract class EditableField
@@ -389,13 +396,6 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       this.__controller.scrollHoriz();
       const cursor = this.__controller.cursor;
       if (this.__controller.blurred) cursor.hide().parent.blur(cursor);
-      return this;
-    }
-    getForeignObject(id: string): HTMLElement | null {
-      return this.__controller.getForeignObjectRegistry().get(id);
-    }
-    registerForeignObject(id: string, element: HTMLElement) {
-      this.__controller.getForeignObjectRegistry().register(id, element);
       return this;
     }
     foreignObject(id: string, element: HTMLElement) {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -391,6 +391,13 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       if (this.__controller.blurred) cursor.hide().parent.blur(cursor);
       return this;
     }
+    getForeignObject(id: string): HTMLElement | null {
+      return this.__controller.getForeignObjectRegistry().get(id);
+    }
+    registerForeignObject(id: string, element: HTMLElement) {
+      this.__controller.getForeignObjectRegistry().register(id, element);
+      return this;
+    }
     foreignObject(id: string, element: HTMLElement) {
       // Register the foreign object in the internal registry
       this.__controller.getForeignObjectRegistry().register(id, element);

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -113,6 +113,7 @@ class Options {
   logAriaAlerts?: boolean;
   onPaste?: () => void;
   onCut?: () => void;
+  confirmForeignObjectDelete?: (objectId: string) => boolean;
   overrideTypedText?: (text: string) => void;
   overrideKeystroke: (key: string, event: KeyboardEvent) => void;
   autoOperatorNames: AutoDict;

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -361,13 +361,9 @@ class Controller_keystroke extends Controller_focusBlur {
 
     // Let the host veto deletion of a foreignobject embed (single-node delete only;
     // range-deletes go through notify('edit') and are not guarded here).
-    if (
-      !cursor.selection &&
-      cursorEl &&
-      (cursorEl.constructor as { isForeignObject?: boolean }).isForeignObject
-    ) {
+    if (!cursor.selection && cursorEl instanceof ForeignObjectCommand) {
       const confirmFn = cursor.options.confirmForeignObjectDelete;
-      const objectId = (cursorEl as { objectId?: string }).objectId;
+      const objectId = cursorEl.objectId;
       if (confirmFn && objectId && !confirmFn(objectId)) return this;
     }
 

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -358,6 +358,19 @@ class Controller_keystroke extends Controller_focusBlur {
     prayDirection(dir);
     var cursor = this.cursor;
     var cursorEl = cursor[dir] as MQNode;
+
+    // Let the host veto deletion of a foreignobject embed (single-node delete only;
+    // range-deletes go through notify('edit') and are not guarded here).
+    if (
+      !cursor.selection &&
+      cursorEl &&
+      (cursorEl.constructor as { isForeignObject?: boolean }).isForeignObject
+    ) {
+      const confirmFn = cursor.options.confirmForeignObjectDelete;
+      const objectId = (cursorEl as { objectId?: string }).objectId;
+      if (confirmFn && objectId && !confirmFn(objectId)) return this;
+    }
+
     var cursorElParent = cursor.parent.parent;
     var ctrlr = cursor.controller;
 


### PR DESCRIPTION
## Summary
- Adds `getForeignObject(id)` and `registerForeignObject(id, element)` to `EditableField`
- Allows callers to look up or register foreign objects without inserting LaTeX at the cursor